### PR TITLE
Multi repo jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v1.0.0 - 2021-XX-XX
+
+### Added
+
+- Updated git repository settings form to have a custom clean method to enfroce
+a template path in case of more than 1 repository selected.
+
 ## v0.9.10 - 2021-11
 
 ### Announcements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,12 @@
 
 ### Added
 
-- Updated git repository settings form to have a custom clean method to enfroce
-a template path in case of more than 1 repository selected.
+- Updated GoldenConfigSettings form to have a custom clean method to enfroce
+a template path in case of more than 1 repository selected for backup or inteded repos.
+- Updated backup job to execute against multiple repos if available based on pattern matching
+- Updated intended job to execute against multiple repos if available based on pattern matching
+- Updated compliance job to execute from multiple repos if available based on pattern matching
+- Added utility function to generate the root path based on available template path
 
 ## v0.9.10 - 2021-11
 

--- a/nautobot_golden_config/forms.py
+++ b/nautobot_golden_config/forms.py
@@ -8,7 +8,7 @@ from nautobot.dcim.models import Device, Platform, Region, Site, DeviceRole, Dev
 from nautobot.extras.models import Status
 from nautobot.extras.models import GitRepository
 from nautobot.tenancy.models import Tenant, TenantGroup
-from nautobot.utilities.forms import DynamicModelMultipleChoiceField, StaticSelect2Multiple
+from nautobot.utilities.forms import StaticSelect2Multiple
 
 from nautobot_golden_config import models
 
@@ -364,8 +364,12 @@ class GoldenConfigSettingFeatureForm(
         super().clean()
         if self.cleaned_data.get("backup_repository").count() > 1:
             if not self.cleaned_data.get("backup_repository_template"):
-                raise forms.ValidationError("If more than one backup repository specified, you must provide a backup repository template.")
-            
+                raise forms.ValidationError(
+                    "If more than one backup repository specified, you must provide a backup repository template."
+                )
+
         if self.cleaned_data.get("intended_repository").count() > 1:
             if not self.cleaned_data.get("intended_repository_template"):
-                raise forms.ValidationError("If more than one intended repository specified, you must provide an intended repository template.")
+                raise forms.ValidationError(
+                    "If more than one intended repository specified, you must provide an intended repository template."
+                )

--- a/nautobot_golden_config/jobs.py
+++ b/nautobot_golden_config/jobs.py
@@ -175,7 +175,7 @@ class BackupJob(Job, FormEntry):
         LOGGER.debug("Pull Backup config repo.")
         backup_repo.commit_with_added(f"BACKUP JOB {now}")
         backup_repo.push()
-        
+
     @commit_check
     def run(self, data, commit):
         """Run config backup process."""
@@ -185,10 +185,10 @@ class BackupJob(Job, FormEntry):
         golden_settings = GoldenConfigSetting.objects.first()
         
         if golden_settings.backup_repository.count() == 1:
-            self._backup(golden_settings.backup_repository, data, now)
+            self._backup(golden_settings.backup_repository.first(), data, now)
         else:
             for repo in golden_settings.backup_repository.all():
-                self._backup(repo.backup_repository, data, now)
+                self._backup(repo, data, now)
 
 
 class AllGoldenConfig(Job):

--- a/nautobot_golden_config/jobs.py
+++ b/nautobot_golden_config/jobs.py
@@ -96,11 +96,15 @@ class ComplianceJob(Job, FormEntry):
         """Run config compliance report script."""
         # pylint: disable-msg=too-many-locals
         # pylint: disable=unused-argument
+        golden_settings = GoldenConfigSetting.objects.first()
+        backup_repos = [git_wrapper(self, repo, "backup") for repo in golden_settings.backup_repository.all()]
+        intended_repos = [git_wrapper(self, repo, "intended") for repo in golden_settings.intended_repository.all()]
+        config_compliance(self, data, backup_repos, intended_repos)
 
-        backup_repo = git_wrapper(self, GoldenConfigSetting.objects.first().backup_repository, "backup")
-        intended_repo = git_wrapper(self, GoldenConfigSetting.objects.first().intended_repository, "intended")
+        # backup_repo = git_wrapper(self, GoldenConfigSetting.objects.first().backup_repository, "backup")
+        # intended_repo = git_wrapper(self, GoldenConfigSetting.objects.first().intended_repository, "intended")
 
-        config_compliance(self, data, backup_repo.path, intended_repo.path)
+        # config_compliance(self, data, backup_repo.path, intended_repo.path)
 
 
 class IntendedJob(Job, FormEntry):

--- a/nautobot_golden_config/nornir_plays/config_backup.py
+++ b/nautobot_golden_config/nornir_plays/config_backup.py
@@ -55,8 +55,6 @@ def run_backup(  # pylint: disable=too-many-arguments
     backup_obj.backup_last_attempt_date = task.host.defaults.data["now"]
     backup_obj.save()
 
-    backedup_device = {"device": []}
-
     for backup_root_dir in backup_root_folder:
         if global_settings.backup_repository_template:
             repo_template = check_jinja_template(obj, logger, global_settings.backup_repository_template)
@@ -68,36 +66,32 @@ def run_backup(  # pylint: disable=too-many-arguments
         backup_path_template_obj = check_jinja_template(obj, logger, global_settings.backup_path_template)
         backup_file = os.path.join(backup_root_folder, backup_path_template_obj)
 
-        if task.host.name not in backedup_device["device"]:
-            if global_settings.backup_test_connectivity is not False:
-                task.run(
-                    task=dispatcher,
-                    name="TEST CONNECTIVITY",
-                    method="check_connectivity",
-                    obj=obj,
-                    logger=logger,
-                    default_drivers_mapping=get_dispatcher(),
-                )
-            running_config = task.run(
+        if global_settings.backup_test_connectivity is not False:
+            task.run(
                 task=dispatcher,
-                name="SAVE BACKUP CONFIGURATION TO FILE",
-                method="get_config",
+                name="TEST CONNECTIVITY",
+                method="check_connectivity",
                 obj=obj,
                 logger=logger,
-                backup_file=backup_file,
-                remove_lines=remove_regex_dict.get(obj.platform.slug, []),
-                substitute_lines=replace_regex_dict.get(obj.platform.slug, []),
                 default_drivers_mapping=get_dispatcher(),
-            )[1].result["config"]
+            )
+        running_config = task.run(
+            task=dispatcher,
+            name="SAVE BACKUP CONFIGURATION TO FILE",
+            method="get_config",
+            obj=obj,
+            logger=logger,
+            backup_file=backup_file,
+            remove_lines=remove_regex_dict.get(obj.platform.slug, []),
+            substitute_lines=replace_regex_dict.get(obj.platform.slug, []),
+            default_drivers_mapping=get_dispatcher(),
+        )[1].result["config"]
 
-            backup_obj.backup_last_success_date = task.host.defaults.data["now"]
-            backup_obj.backup_config = running_config
-            backup_obj.save()
-            logger.log_success(obj, "Successfully backed up device.")
-        else:
-            logger.DEBUG("Device already backed up in another repository %s", task.host.name)
+        backup_obj.backup_last_success_date = task.host.defaults.data["now"]
+        backup_obj.backup_config = running_config
+        backup_obj.save()
 
-        backedup_device["device"].append(task.host.name)
+        logger.log_success(obj, "Successfully backed up device.")
         return Result(host=task.host, result=running_config)
 
 

--- a/nautobot_golden_config/nornir_plays/config_backup.py
+++ b/nautobot_golden_config/nornir_plays/config_backup.py
@@ -18,6 +18,7 @@ from nautobot_plugin_nornir.utils import get_dispatcher
 
 from nautobot_golden_config.utilities.helper import (
     get_job_filter,
+    get_root_folder,
     verify_global_settings,
     check_jinja_template,
 )
@@ -56,13 +57,7 @@ def run_backup(  # pylint: disable=too-many-arguments
     backup_obj.save()
 
     for backup_root_dir in backup_root_folder:
-        if global_settings.backup_repository_template:
-            repo_template = check_jinja_template(obj, logger, global_settings.backup_repository_template)
-            # TODO: How does this path get defined? Can we bring it from somewhere?
-            backup_root_folder = f"/opt/nautobot/git/{repo_template}"
-        else:
-            backup_root_folder = backup_root_dir.path
-
+        backup_root_folder = get_root_folder(backup_root_dir, "backup", obj, logger, global_settings)
         backup_path_template_obj = check_jinja_template(obj, logger, global_settings.backup_path_template)
         backup_file = os.path.join(backup_root_folder, backup_path_template_obj)
 

--- a/nautobot_golden_config/nornir_plays/config_compliance.py
+++ b/nautobot_golden_config/nornir_plays/config_compliance.py
@@ -20,6 +20,7 @@ from nautobot_plugin_nornir.constants import NORNIR_SETTINGS
 from nautobot_golden_config.models import ComplianceRule, ConfigCompliance, GoldenConfigSetting, GoldenConfig
 from nautobot_golden_config.utilities.helper import (
     get_job_filter,
+    get_root_folder,
     verify_global_settings,
     check_jinja_template,
 )
@@ -76,53 +77,55 @@ def run_compliance(  # pylint: disable=too-many-arguments,too-many-locals
     compliance_obj.compliance_last_attempt_date = task.host.defaults.data["now"]
     compliance_obj.save()
 
-    intended_path_template_obj = check_jinja_template(obj, logger, global_settings.intended_path_template)
+    for intended_repo, backup_repo in intended_root_folder, backup_root_path:
+        intended_root_folder = get_root_folder(intended_repo, "intended", obj, logger, global_settings)
+        intended_path_template_obj = check_jinja_template(obj, logger, global_settings.intended_path_template)
+        intended_file = os.path.join(intended_root_folder, intended_path_template_obj)
+        if not os.path.exists(intended_file):
+            logger.log_failure(obj, f"Unable to locate intended file for device at {intended_file}")
+            raise NornirNautobotException()
 
-    intended_file = os.path.join(intended_root_folder, intended_path_template_obj)
+        backup_root_path = get_root_folder(backup_repo, "backup", obj, logger, global_settings)
+        backup_template = check_jinja_template(obj, logger, global_settings.backup_path_template)
+        backup_file = os.path.join(backup_root_path, backup_template)
+        if not os.path.exists(backup_file):
+            logger.log_failure(obj, f"Unable to locate backup file for device at {backup_file}")
+            raise NornirNautobotException()
 
-    if not os.path.exists(intended_file):
-        logger.log_failure(obj, f"Unable to locate intended file for device at {intended_file}")
-        raise NornirNautobotException()
+        platform = obj.platform.slug
+        if not rules.get(platform):
+            logger.log_failure(obj, f"There is no defined `Configuration Rule` for platform slug `{platform}`.")
+            raise NornirNautobotException()
 
-    backup_template = check_jinja_template(obj, logger, global_settings.backup_path_template)
-    backup_file = os.path.join(backup_root_path, backup_template)
+        if get_platform(platform) not in parser_map.keys():
+            logger.log_failure(
+                obj, f"There is currently no parser support for platform slug `{get_platform(platform)}`."
+            )
+            raise NornirNautobotException()
 
-    if not os.path.exists(backup_file):
-        logger.log_failure(obj, f"Unable to locate backup file for device at {backup_file}")
-        raise NornirNautobotException()
+        backup_cfg = _open_file_config(backup_file)
+        intended_cfg = _open_file_config(intended_file)
 
-    platform = obj.platform.slug
-    if not rules.get(platform):
-        logger.log_failure(obj, f"There is no defined `Configuration Rule` for platform slug `{platform}`.")
-        raise NornirNautobotException()
+        # TODO: Make this atomic with compliance_obj step.
+        for rule in rules[obj.platform.slug]:
+            # using update_or_create() method to conveniently update actual obj or create new one.
+            ConfigCompliance.objects.update_or_create(
+                device=obj,
+                rule=rule["obj"],
+                defaults={
+                    "actual": section_config(rule, backup_cfg, get_platform(platform)),
+                    "intended": section_config(rule, intended_cfg, get_platform(platform)),
+                    "missing": "",
+                    "extra": "",
+                },
+            )
 
-    if get_platform(platform) not in parser_map.keys():
-        logger.log_failure(obj, f"There is currently no parser support for platform slug `{get_platform(platform)}`.")
-        raise NornirNautobotException()
+        compliance_obj.compliance_last_success_date = task.host.defaults.data["now"]
+        compliance_obj.compliance_config = "\n".join(diff_files(backup_file, intended_file))
+        compliance_obj.save()
+        logger.log_success(obj, "Successfully tested compliance.")
 
-    backup_cfg = _open_file_config(backup_file)
-    intended_cfg = _open_file_config(intended_file)
-
-    # TODO: Make this atomic with compliance_obj step.
-    for rule in rules[obj.platform.slug]:
-        # using update_or_create() method to conveniently update actual obj or create new one.
-        ConfigCompliance.objects.update_or_create(
-            device=obj,
-            rule=rule["obj"],
-            defaults={
-                "actual": section_config(rule, backup_cfg, get_platform(platform)),
-                "intended": section_config(rule, intended_cfg, get_platform(platform)),
-                "missing": "",
-                "extra": "",
-            },
-        )
-
-    compliance_obj.compliance_last_success_date = task.host.defaults.data["now"]
-    compliance_obj.compliance_config = "\n".join(diff_files(backup_file, intended_file))
-    compliance_obj.save()
-    logger.log_success(obj, "Successfully tested compliance.")
-
-    return Result(host=task.host)
+        return Result(host=task.host)
 
 
 def config_compliance(job_result, data, backup_root_path, intended_root_folder):

--- a/nautobot_golden_config/utilities/helper.py
+++ b/nautobot_golden_config/utilities/helper.py
@@ -100,10 +100,12 @@ def get_root_folder(
         repo_template = global_settings.intended_repository_template
     elif repo_type == "backup":
         repo_template = global_settings.backup_repository_template
+    # elif jinja template multiple support?
 
     if repo_template:
         repo_template = check_jinja_template(obj, logger, repo_template)
         backup_root_folder = f"/opt/nautobot/git/{repo_template}"
     else:
         backup_root_folder = repo.path
+
     return backup_root_folder

--- a/nautobot_golden_config/utilities/helper.py
+++ b/nautobot_golden_config/utilities/helper.py
@@ -104,6 +104,9 @@ def get_root_folder(
 
     if repo_template:
         repo_template = check_jinja_template(obj, logger, repo_template)
+        # Figure out how to get this from settings or something?
+        # repo.path returns(example) = "/opt/nautobot/git/repo-name/"
+        # Can we do something with this ^
         backup_root_folder = f"/opt/nautobot/git/{repo_template}"
     else:
         backup_root_folder = repo.path

--- a/tasks.py
+++ b/tasks.py
@@ -159,6 +159,13 @@ def stop(context):
 
 
 @task
+def restart(context):
+    """Gracefully restart all containers."""
+    print("Restarting Nautobot...")
+    docker_compose(context, "restart")
+
+
+@task
 def destroy(context):
     """Destroy all containers and volumes.
 


### PR DESCRIPTION
- Updated backup job to execute against multiple repos if available based on pattern matching
- Updated intended job to execute against multiple repos if available based on pattern matching
- Updated compliance job to execute from multiple repos if available based on pattern matching
-  Added utility function to generate the root path based on available template path
- Small update to changelog
- Updated configsettings forms to include a custom clean method for enforcement of template path based on if more than one backup-repo or intended-repo