### PR TITLE
Compliance report bug fix + auto-slug

### DIFF
--- a/nautobot_golden_config/forms.py
+++ b/nautobot_golden_config/forms.py
@@ -8,7 +8,8 @@ from nautobot.dcim.models import Device, Platform, Region, Site, DeviceRole, Dev
 from nautobot.extras.models import Status
 from nautobot.extras.models import GitRepository
 from nautobot.tenancy.models import Tenant, TenantGroup
-from nautobot.utilities.forms import StaticSelect2Multiple
+from nautobot.utilities.forms import StaticSelect2Multiple, SlugField
+
 
 from nautobot_golden_config import models
 from nautobot_golden_config.utilities.helper import clean_config_settings
@@ -168,6 +169,8 @@ class ComplianceFeatureForm(
     utilities_forms.BootstrapMixin, extras_forms.CustomFieldModelForm, extras_forms.RelationshipModelForm
 ):
     """Filter Form for ComplianceFeature instances."""
+
+    slug = SlugField()
 
     class Meta:
         """Boilerplate form Meta data for compliance feature."""

--- a/nautobot_golden_config/views.py
+++ b/nautobot_golden_config/views.py
@@ -188,7 +188,7 @@ class ConfigComplianceListView(generic.ObjectListView):
         return pivot(
             self.queryset,
             ["device", "device__name"],
-            "rule__feature__slug",
+            "rule__feature__name",
             "compliance_int",
             aggregation=Max,
         )


### PR DESCRIPTION
- Added `SlugField` to Feature Form to auto-populate the slug
- Updated the views `pivot` to extract the feature__name, not the slug so that it matches in the ConfigComplianceColumn and render the CheckMark / Red X accordingly.